### PR TITLE
install.sh: add fallback systemd unit for v4l2loopback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,15 +8,36 @@ echo "
 Description=Loads v4l2loopback
 DefaultDependencies=false
 After=systemd-user-sessions.service
+OnFailure=v4l2loopback-silverblue-failure.service
 [Service]
 Type=simple
 WorkingDirectory=`pwd`
 ExecStart=sh `pwd`/load-v4l2loopback.sh
+Restart=on-failure
+RestartSec=60
 [Install]
 Alias=v4l2loopback-silverblue.service
 WantedBy=multi-user.target" > /etc/systemd/system/v4l2loopback-silverblue.service
 
+
+echo "Creating service on /etc/systemd/system/v4l2loopback-silverblue-failure.service ..."
+
+echo "
+[Unit]
+Description=Builds v4l2loopback
+DefaultDependencies=false
+After=systemd-user-sessions.service
+[Service]
+User=`logname`
+Type=simple
+WorkingDirectory=`pwd`
+ExecStart=sh `pwd`/podman_build.sh --scope user
+[Install]
+Alias=v4l2loopback-silverblue-failure.service
+WantedBy=multi-user.target" > /etc/systemd/system/v4l2loopback-silverblue-failure.service
+
 chmod +x /etc/systemd/system/v4l2loopback-silverblue.service
+chmod +x /etc/systemd/system/v4l2loopback-silverblue-failure.service
 
 echo "Enable service..."
 systemctl enable v4l2loopback-silverblue

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,6 +1,8 @@
 echo "Removing service..."
 systemctl disable v4l2loopback-silverblue
 rm /etc/systemd/system/v4l2loopback-silverblue.service
+rm /etc/systemd/system/v4l2loopback-silverblue-failure.service
+
 echo "Unloading module v4l2loopback"
 rmmod `pwd`/build/v4l2loopback/v4l2loopback.ko
 echo "Ok.Bye bye"


### PR DESCRIPTION
This change introduces a second systemd unit,
`v4l2loopback-silverblue-failure.service`, which rebuilds the v4l2loopback module if `v4l2loopback-silverblue.service` fails to load the driver.

This is useful after system updates when the module has not yet been rebuilt, preventing driver load failures.

	modified:   install.sh
	modified:   uninstall.sh